### PR TITLE
test: node v8-11 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 
 node_js:
-  - "10"
+  - 8
+  - 9
+  - 10
+  - 11
 
 after_success: npm run coverage

--- a/test/statet.test.js
+++ b/test/statet.test.js
@@ -95,7 +95,7 @@ suite ('StateT', function() {
     test ('should throw if M is not ChainRec', function() {
       return assert.throws (
         function() { return Z.chainRec ([], Function.prototype, 0); },
-        {message: 'ChainRec.methods.chainRec(...) is not a function'}
+        /ChainRec\.methods\.chainRec\(\.\.\.\) is not a function/
       );
     });
     test ('should be stack-safe', function() {


### PR DESCRIPTION
# Motivation

Cover at least from LTS to Current node versions.

# Changes

Travis now will test against node v8,9,10,11