### PR TITLE
Update sanctuary-scripts for esm support in tests

### DIFF
--- a/.config
+++ b/.config
@@ -2,3 +2,5 @@ author-name = WEAREREASONABLEPEOPLE B.V.
 repo-owner = wearereasonablepeople
 repo-name = monastic
 source-files = index.mjs
+opening-delimiter = ```js
+module-type = esm

--- a/package.json
+++ b/package.json
@@ -42,11 +42,9 @@
     "fantasy-laws": "^1.1.0",
     "jsverify": "^0.8.3",
     "license-checker": "^20.1.0",
-    "nyc": "^12.0.2",
     "rollup": "^0.63.4",
     "sanctuary-maybe": "^1.0.0",
-    "sanctuary-scripts": "^2.0.0",
-    "sanctuary-style": "^2.0.0"
+    "sanctuary-scripts": "^3.2.0"
   },
   "dependencies": {
     "sanctuary-type-classes": "^9.0.0"

--- a/scripts/test
+++ b/scripts/test
@@ -2,11 +2,7 @@
 
 set -euf -o pipefail
 
-source "${BASH_SOURCE%/*}/../node_modules/sanctuary-scripts/functions"
-
-branches="$(get min-branch-coverage)"
-
 npm run licensetest
 npm run deps
-node_modules/.bin/nyc --extension .mjs node_modules/.bin/mocha
-node_modules/.bin/nyc check-coverage --branches $branches
+
+sanctuary-test "$@"


### PR DESCRIPTION
# Motivation

`sanctuary-scripts` will soon support `.mjs` files when running tests, so we don't need custom testing logic anymore.

# Changes

- `sanctuary-scripts` updated to the appropriate draft version
- Custom `test` script now dispatches back to `sanctuary-test`
- Added `opening-delimiter` to `.config`